### PR TITLE
remove logger and just return error about not successful request

### DIFF
--- a/librato.go
+++ b/librato.go
@@ -9,17 +9,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 )
 
 var (
-	// Use this variable to set a custom logger or set it to nil to disable logging.
-	Logger = log.New(os.Stderr, "librato", log.LstdFlags)
-
 	// Librato suggests max. 300 measurements per POST. There is also an undocumented
 	// payload size limit which triggers an HTTP 413 - Request Entity Too Large response.
 	// So the client will make a request either at MaxMetrics measurements or when the timer
@@ -260,9 +255,10 @@ func (c *TimeCollatedClient) makeRequest(data *bytes.Buffer, url string) error {
 	}
 
 	// http://api-docs-archive.librato.com/#http-status-codes
-	if res.StatusCode > 204 && Logger != nil {
+	if res.StatusCode > 204 {
 		b, _ := ioutil.ReadAll(res.Body)
-		Logger.Printf("status:%d, error: %s\n", res.StatusCode, string(b))
+		res.Body.Close()
+		return fmt.Errorf("unsuccessful request: response status: %d, error: %q", res.StatusCode, string(b))
 	}
 
 	return nil


### PR DESCRIPTION
this logger is more annoyance than actual help, would simpler just to return an error to the caller, where he can decide what to do with it